### PR TITLE
Update to Azure Service Runtime 2.7

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
-:minor: 0
+:minor: 2
 :patch: 0
-:special: ''
+:special: '-beta1'
 :metadata: ''

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -60,7 +60,7 @@ msbuild :build do |msb|
   msb.properties :Configuration => "Release",
     :Platform => 'Any CPU'
   msb.use :net4
-  msb.targets :Clean, :Build
+  msb.targets :Rebuild
   msb.properties[:SignAssembly] = 'true'
   msb.properties[:AssemblyOriginatorKeyFile] = props[:keyfile]
   msb.solution = 'src/Topshelf.Azure.sln'
@@ -104,15 +104,14 @@ end
 nuspec :create_nuspec do |nuspec|
   nuspec.id = 'Topshelf.Azure'
   nuspec.version = NUGET_VERSION
-  nuspec.authors = 'Chris Patterson'
+  nuspec.authors = ['Chris Patterson']
   nuspec.description = 'Topshelf.Azure supports hosting Topshelf services in an Azure worker role'
   nuspec.title = 'Topshelf.Azure'
-  nuspec.projectUrl = 'http://github.com/Topshelf/Topshelf.Azure'
+  nuspec.project_url  = 'http://github.com/Topshelf/Topshelf.Azure'
   nuspec.language = "en-US"
-  nuspec.licenseUrl = "http://www.apache.org/licenses/LICENSE-2.0"
-  nuspec.requireLicenseAcceptance = "false"
+  nuspec.license_url = "http://www.apache.org/licenses/LICENSE-2.0"
   nuspec.dependency "Topshelf", "3.1.4"
-  nuspec.dependency "Unofficial.Microsoft.WindowsAzure.ServiceRuntime", "2.5.0.0"
+  nuspec.dependency "Unofficial.Microsoft.WindowsAzure.ServiceRuntime", "2.7.0.0"
   nuspec.output_file = File.join(props[:artifacts], 'Topshelf.Azure.nuspec')
   add_files props[:output], 'Topshelf.Azure.{dll,pdb,xml}', nuspec
   nuspec.file(File.join(props[:src], "Topshelf.Azure\\**\\*.cs").gsub("/","\\"), "src")

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -110,7 +110,7 @@ nuspec :create_nuspec do |nuspec|
   nuspec.project_url  = 'http://github.com/Topshelf/Topshelf.Azure'
   nuspec.language = "en-US"
   nuspec.license_url = "http://www.apache.org/licenses/LICENSE-2.0"
-  nuspec.dependency "Topshelf", "3.1.4"
+  nuspec.dependency "Topshelf", "3.2.0"
   nuspec.dependency "Unofficial.Microsoft.WindowsAzure.ServiceRuntime", "2.7.0.0"
   nuspec.output_file = File.join(props[:artifacts], 'Topshelf.Azure.nuspec')
   add_files props[:output], 'Topshelf.Azure.{dll,pdb,xml}', nuspec

--- a/src/SampleCloudService/SampleCloudService.ccproj
+++ b/src/SampleCloudService/SampleCloudService.ccproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>2.5</ProductVersion>
+    <ProductVersion>2.7</ProductVersion>
     <ProjectGuid>3bffc829-233c-42f4-b8a8-b66a41c407fd</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -57,7 +57,7 @@
   <!-- Import the target files for this project template -->
   <PropertyGroup>
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
-    <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.5\</CloudExtensionsDir>
+    <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.7\</CloudExtensionsDir>
   </PropertyGroup>
   <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets" />
 </Project>

--- a/src/SampleCloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/SampleCloudService/ServiceConfiguration.Cloud.cscfg
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ServiceConfiguration serviceName="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="4" osVersion="*" schemaVersion="2014-06.2.4">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ServiceConfiguration serviceName="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="4" osVersion="*" schemaVersion="2015-04.2.6">
   <Role name="SampleWorkerRoleService">
     <Instances count="1" />
     <ConfigurationSettings>
       <Setting name="TestPhrase" value="Big, puffy clouds." />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
     </ConfigurationSettings>
   </Role>
 </ServiceConfiguration>

--- a/src/SampleCloudService/ServiceConfiguration.Local.cscfg
+++ b/src/SampleCloudService/ServiceConfiguration.Local.cscfg
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
-<ServiceConfiguration serviceName="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="4" osVersion="*" schemaVersion="2014-06.2.4">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ServiceConfiguration serviceName="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="4" osVersion="*" schemaVersion="2015-04.2.6">
   <Role name="SampleWorkerRoleService">
     <Instances count="1" />
     <ConfigurationSettings>
       <Setting name="TestPhrase" value="Clear sky." />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
     </ConfigurationSettings>
   </Role>
 </ServiceConfiguration>

--- a/src/SampleCloudService/ServiceDefinition.csdef
+++ b/src/SampleCloudService/ServiceDefinition.csdef
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ServiceDefinition name="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2014-06.2.4">
+<ServiceDefinition name="SampleCloudService" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2015-04.2.6">
   <WorkerRole name="SampleWorkerRoleService" vmsize="Small">
     <ConfigurationSettings>
       <Setting name="TestPhrase" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
     </ConfigurationSettings>
   </WorkerRole>
 </ServiceDefinition>

--- a/src/SampleWorkerRoleService/Program.cs
+++ b/src/SampleWorkerRoleService/Program.cs
@@ -1,6 +1,6 @@
 ﻿namespace SampleWorkerRoleService
 {
-    using Microsoft.WindowsAzure;
+    using Microsoft.Azure;
     using Topshelf;
     using Topshelf.HostConfigurators;
     using Topshelf.Logging;

--- a/src/SampleWorkerRoleService/SampleWorkerRoleService.csproj
+++ b/src/SampleWorkerRoleService/SampleWorkerRoleService.csproj
@@ -47,13 +47,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Configuration">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="Microsoft.WindowsAzure.Configuration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.1.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage">
@@ -69,8 +70,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
-    <Reference Include="Topshelf">
-      <HintPath>..\packages\Topshelf.3.1.4\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=3.2.150.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.3.2.0\lib\net40-full\Topshelf.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SampleWorkerRoleService/packages.config
+++ b/src/SampleWorkerRoleService/packages.config
@@ -3,9 +3,9 @@
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
-  <package id="Topshelf" version="3.1.4" targetFramework="net45" />
+  <package id="Topshelf" version="3.2.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/src/SolutionVersion.cs
+++ b/src/SolutionVersion.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Topshelf.Azure support running Topshelf services as a worker role on Microsoft Azure.")]
 [assembly: AssemblyProduct("Topshelf.Azure")]
 [assembly: AssemblyCopyright("Copyright 2015-2015 Chris Patterson, All rights reserved.")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyFileVersion("1.0.0")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0")]
 
-[assembly: AssemblyInformationalVersion("1.0.0.ce310e")]
+[assembly: AssemblyInformationalVersion("1.2.0-beta1.ba01f0")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(true)]

--- a/src/Topshelf.Azure.sln
+++ b/src/Topshelf.Azure.sln
@@ -1,10 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Azure", "Topshelf.Azure\Topshelf.Azure.csproj", "{0BDE63C1-8007-4750-9264-C898620B1430}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{DA3763EE-5FD2-4C3B-9FB9-D93B436FE269}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
@@ -14,7 +12,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{DA3763
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{433B255D-F044-420D-846F-0C4C81902D37}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Topshelf.Azure", "Topshelf.Azure\Topshelf.Azure.csproj", "{0BDE63C1-8007-4750-9264-C898620B1430}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleWorkerRoleService", "SampleWorkerRoleService\SampleWorkerRoleService.csproj", "{941A7AB3-81E2-4910-8D74-B28A79560830}"
+EndProject
+Project("{CC5FD16D-436D-48AD-A40C-5A424C6E3E79}") = "SampleCloudService", "SampleCloudService\SampleCloudService.ccproj", "{3BFFC829-233C-42F4-B8A8-B66A41C407FD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,6 +32,10 @@ Global
 		{941A7AB3-81E2-4910-8D74-B28A79560830}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{941A7AB3-81E2-4910-8D74-B28A79560830}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{941A7AB3-81E2-4910-8D74-B28A79560830}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BFFC829-233C-42F4-B8A8-B66A41C407FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BFFC829-233C-42F4-B8A8-B66A41C407FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BFFC829-233C-42F4-B8A8-B66A41C407FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BFFC829-233C-42F4-B8A8-B66A41C407FD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -37,5 +43,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{433B255D-F044-420D-846F-0C4C81902D37} = {DA3763EE-5FD2-4C3B-9FB9-D93B436FE269}
 		{941A7AB3-81E2-4910-8D74-B28A79560830} = {433B255D-F044-420D-846F-0C4C81902D37}
+		{3BFFC829-233C-42F4-B8A8-B66A41C407FD} = {433B255D-F044-420D-846F-0C4C81902D37}
 	EndGlobalSection
 EndGlobal

--- a/src/Topshelf.Azure/Topshelf.Azure.csproj
+++ b/src/Topshelf.Azure/Topshelf.Azure.csproj
@@ -32,14 +32,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.7.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
       <Private>True</Private>
-      <HintPath>..\packages\Unofficial.Microsoft.WindowsAzure.ServiceRuntime.2.5.0.0\lib\net40\Microsoft.WindowsAzure.ServiceRuntime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Topshelf">
-      <HintPath>..\packages\Topshelf.3.1.4\lib\net40-full\Topshelf.dll</HintPath>
+    <Reference Include="Topshelf, Version=3.2.150.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Topshelf.3.2.0\lib\net40-full\Topshelf.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Topshelf.Azure/packages.config
+++ b/src/Topshelf.Azure/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Topshelf" version="3.1.4" targetFramework="net45" />
-  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.5.0.0" targetFramework="net45" />
+  <package id="Topshelf" version="3.2.0" targetFramework="net45" />
+  <package id="Unofficial.Microsoft.WindowsAzure.ServiceRuntime" version="2.7.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Updated packages to support azure service runtime 2.7, which is now the minimum version when using VS 2015.

I left a minor version number hole in case someone wants to push a version that supports Azure 2.6 in between 1.0 and this version.
